### PR TITLE
Fix server online-mode authentication

### DIFF
--- a/src/main/java/org/mcphackers/launchwrapper/protocol/LegacyURLStreamHandler.java
+++ b/src/main/java/org/mcphackers/launchwrapper/protocol/LegacyURLStreamHandler.java
@@ -20,9 +20,11 @@ public class LegacyURLStreamHandler extends URLStreamHandlerProxy {
 	protected URLConnection openConnection(URL url) throws IOException {
 		String host = url.getHost();
 		String path = url.getPath();
+		String file = url.getFile();
 		if(host.endsWith(".minecraft.net") || host.equals("s3.amazonaws.com")) {
 			if(path.equals("/game/joinserver.jsp"))
-				return super.openConnection(new URL("http", "session.minecraft.net", path));
+				// TODO: update this to use the "sessionserver.mojang.com" API instead?
+				return super.openConnection(new URL("https", "session.minecraft.net", file));
 			if(path.equals("/login/session.jsp"))
 				return new BasicResponseURLConnection(url, "ok");
 			if(host.equals("login.minecraft.net") && path.equals("/session"))


### PR DESCRIPTION
This PR _should_ fix the "**Failed to verify username!**" error when attempting to connect to online-mode Alpha/Beta servers.

The wrapper handles [http://www.minecraft.net/game/joinserver.jsp](https://session.minecraft.net/game/joinserver.jsp) just fine, however, the implementation is technically broken because it uses the string from `url.getPath()` which does not include any query information. This results in the URL responding with **`Bad login`** and the server then kicking the user.

Related issues: #5, #7.