### PR TITLE
Slightly rework how the wrapper handles arguments/parameters.

### DIFF
--- a/src/main/java/org/mcphackers/launchwrapper/LaunchConfig.java
+++ b/src/main/java/org/mcphackers/launchwrapper/LaunchConfig.java
@@ -75,7 +75,6 @@ public class LaunchConfig {
 	public final LaunchParameterSwitch survival	 			= new LaunchParameterSwitch("survival", false, true);
 	public final LaunchParameterString serverURL 			= new LaunchParameterString("serverURL", null, true);
 	public final LaunchParameterString serverSHA1 			= new LaunchParameterString("serverSHA1", null, true);
-	public final LaunchParameterSwitch noParameters	 			= new LaunchParameterSwitch("noParameters", false, true);
 	// clang-format on
 
 	private static File getDefaultGameDir() {
@@ -172,13 +171,6 @@ public class LaunchConfig {
 				}
 			}
 			arguments.add(param);
-		}
-		if (!noParameters.get().equals(Boolean.TRUE)) {
-			for (LaunchParameter<?> param : parameters.values()) {
-				if (!arguments.contains(param)) {
-					arguments.add(param);
-				}
-			}
 		}
 		if (levelsDir.get() == null) {
 			levelsDir.set(new File(gameDir.get(), "levels"));


### PR DESCRIPTION
Since LaunchWrapper is able to launch servers, it seems the current way it handles passing arguments to the main method doesn't account for old server versions which expect `nogui` as the first argument if the user wants to launch the server without GUI. This pull request adds a really small (and honestly silly) workaround for this case.

There is likely a much better way of handling arguments passed through for servers but this'll work for now I guess.