### PR TITLE
Fix SkinMC provider, and allow for converting skins on modern versions

### DIFF
--- a/src/main/java/org/mcphackers/launchwrapper/protocol/skin/SkinMCCapeProvider.java
+++ b/src/main/java/org/mcphackers/launchwrapper/protocol/skin/SkinMCCapeProvider.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+import org.mcphackers.launchwrapper.Launch;
 import org.mcphackers.launchwrapper.util.Util;
 
 public class SkinMCCapeProvider implements SkinProvider {
@@ -48,6 +49,8 @@ public class SkinMCCapeProvider implements SkinProvider {
 
 		public byte[] getData() throws IOException {
 			HttpURLConnection httpConnection = (HttpURLConnection)openDirectConnection(new URL(getURL()));
+			// Set User-Agent, otherwise SkinMC will return 403/Forbidden
+			httpConnection.setRequestProperty("User-Agent", "LaunchWrapper/" + Launch.VERSION);
 			if (httpConnection.getResponseCode() != 200) {
 				return null;
 			}
@@ -55,7 +58,7 @@ public class SkinMCCapeProvider implements SkinProvider {
 		}
 
 		public String getURL() {
-			return "https://skinmc.net/api/v1/skinmcCape/" + uuid;
+			return "https://skinmc.net/api/v1/cape/" + uuid;
 		}
 
 		public boolean isSlim() {

--- a/src/main/java/org/mcphackers/launchwrapper/protocol/skin/SkinType.java
+++ b/src/main/java/org/mcphackers/launchwrapper/protocol/skin/SkinType.java
@@ -2,13 +2,13 @@ package org.mcphackers.launchwrapper.protocol.skin;
 
 public enum SkinType {
 	// clang-format off
-    PRE_19A("pre-c0.0.19a"),     // Entire model is mirrored
-    CLASSIC("classic"),          // Before c0.24_ST. Lack of head layer
-    PRE_B1_9("pre-b1.9-pre4"),   // Before b1.9-pre4. Flipped bottom faces on all body parts
-    PRE_1_8("pre-1.8"),          // Before 14w03a. Lack of skin layers
-    // PRE_1_8_PRE("pre-1.8-pre1"),	  // Before 1.8-pre1. Lack of slim model (Use SkinOption.IGNORE_ALEX with pre-1.9)
-    PRE_1_9("pre-1.9"),          // Before 15w47a. Lack of semi-transparency
-    DEFAULT("default");          // Latest skin format
+	PRE_19A("pre-c0.0.19a"),     // Entire model is mirrored
+	CLASSIC("classic"),          // Before c0.24_ST. Lack of head layer
+	PRE_B1_9("pre-b1.9-pre4"),   // Before b1.9-pre4. Flipped bottom faces on all body parts
+	PRE_1_8("pre-1.8"),          // Before 14w03a. Lack of skin layers
+	// PRE_1_8_PRE("pre-1.8-pre1"),	  // Before 1.8-pre1. Lack of slim model (Use SkinOption.IGNORE_ALEX with pre-1.9)
+	PRE_1_9("pre-1.9"),          // Before 15w47a. Lack of semi-transparency
+	DEFAULT("default");          // Latest skin format
 	// clang-format on
 
 	public final String name;


### PR DESCRIPTION
Due to SkinMC changing its API endpoint to grab a player's cape, this was causing issues in skin requests that stopped skins from loading on modern versions. This brings two main changes: if a skin provider returns a skin with NULL data it'll move onto the next provider, and fix the SkinMC provider by updating the URL and setting a user agent so the server no longer returns 403/Forbidden.

Includes a bonus change that allows converting skins on modern versions of Minecraft. Previously, this made `--skinProxy pre-1.8` and `--skinProxy pre-1.9` useless on Minecraft 1.7.x-1.8.x as these versions use AuthLib for skins. The skin's hash is re-calculated accordingly as well. No conversion is attempted for `--skinProxy default` unless `--skinOptions removeHat` is specified.

Also fix the indentation in **`SkinType.java`** to be tabs instead of spaces (for consistency sake.)