### PR TITLE
Quick patch to address an accidental issue from PR #18

### DIFF
--- a/src/main/java/org/mcphackers/launchwrapper/LaunchConfig.java
+++ b/src/main/java/org/mcphackers/launchwrapper/LaunchConfig.java
@@ -172,6 +172,12 @@ public class LaunchConfig {
 			}
 			arguments.add(param);
 		}
+		// Append other parameters which were not parsed above to the end of the arguments list
+		for (LaunchParameter<?> param : parameters.values()) {
+			if (!arguments.contains(param)) {
+				arguments.add(param);
+			}
+		}
 		if (levelsDir.get() == null) {
 			levelsDir.set(new File(gameDir.get(), "levels"));
 		}


### PR DESCRIPTION
PR #18 includes a commit (4cbdd83eeec0a24d190a459a7d213673a49633d8) to remove the **`--noParameters`** switch. I accidentally overlooked the fact that I had also removed the `for` loop which was necessary to append the rest of the wrapper's parameters to the end of the arguments list. This is a quick patch to address that by re-adding the `for` loop. All parameters were otherwise parsed just fine when set by a launcher/user.

This fixes problems with versions that expected certain parameters to always be present. Example: connecting to a server on Classic versions would result in a NPE being thrown because **`mppass`** was not being passed to the client's arguments.