### PR TITLE
Add switch to disable custom Skin URL Connection (--disableSkinFix).

### DIFF
--- a/launchwrapper-micromixin/src/main/java/org/mcphackers/launchwrapper/micromixin/tweak/MicroMixinTweak.java
+++ b/launchwrapper-micromixin/src/main/java/org/mcphackers/launchwrapper/micromixin/tweak/MicroMixinTweak.java
@@ -28,7 +28,7 @@ public class MicroMixinTweak extends Tweak {
 	protected MicroMixinTweaker microMixinTweaker = new MicroMixinTweaker();
 	protected MicroMixinInjection microMixinInjection = new MicroMixinInjection(mods, microMixinTweaker);
 
-	public MicroMixinTweak(LaunchConfig launch, Tweak tweak) {
+	public MicroMixinTweak(Tweak tweak, LaunchConfig launch) {
 		super(launch);
 		if (tweak == null) {
 			throw new NullPointerException("tweak mustn't be null");

--- a/src/main/java/org/mcphackers/launchwrapper/LaunchConfig.java
+++ b/src/main/java/org/mcphackers/launchwrapper/LaunchConfig.java
@@ -77,6 +77,7 @@ public class LaunchConfig {
 	public final LaunchParameterSwitch survival				= new LaunchParameterSwitch("survival", false, true);
 	public final LaunchParameterString serverURL			= new LaunchParameterString("serverURL", null, true);
 	public final LaunchParameterString serverSHA1			= new LaunchParameterString("serverSHA1", null, true);
+	public final LaunchParameterSwitch disableSkinFix		= new LaunchParameterSwitch("disableSkinFix", false, true);
 	// clang-format on
 
 	private static File getDefaultGameDir() {

--- a/src/main/java/org/mcphackers/launchwrapper/protocol/MinecraftURLStreamHandler.java
+++ b/src/main/java/org/mcphackers/launchwrapper/protocol/MinecraftURLStreamHandler.java
@@ -50,7 +50,7 @@ public class MinecraftURLStreamHandler extends URLStreamHandlerProxy {
 				return new ListLevelsURLConnection(url, levelSaveDir);
 			if (path.startsWith("/MinecraftResources/") || path.startsWith("/resources/"))
 				return new AssetURLConnection(url, assets);
-			if (path.startsWith("/MinecraftSkins/") || path.startsWith("/skin/") || path.startsWith("/MinecraftCloaks/") || path.startsWith("/cloak/"))
+			if (!config.disableSkinFix.get() && (path.startsWith("/MinecraftSkins/") || path.startsWith("/skin/") || path.startsWith("/MinecraftCloaks/") || path.startsWith("/cloak/")))
 				return new SkinURLConnection(url, skins);
 			if (host.equals("assets.minecraft.net") && path.equals("/1_6_has_been_released.flag"))
 				if (config.oneSixFlag.get())


### PR DESCRIPTION
This enables use of the Betacraft Proxy for custom legacy skins.

I use a custom skin on the Betacraft Proxy in order to have a separate skin for older versions, so this will allow the usage of that proxy. There might be a better way to do this by calling Betacraft directly, but I don't know how one would even do that. There doesn't seem to be any documentation on the website for that, so I am currently assuming that is impossible without going through the HTTP proxy.